### PR TITLE
v1.1.0: Introduce ignoreDeclarations option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+- Introduce `ignoreDeclarations` option.
+
 ## 1.0.0
 - Support PostCSS 5.x.
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ postcss([
 
 ## Options
 
+### `ignoreDeclarations`
+
+Type: `{ [prop: string]: string; }`
+Required: `false`
+Default: `undefined`
+
+A collection of declarations that you would like to ignore. These could be CSS hacks or something else that you really don't want throwing validation errors. Example below:
+
+```js
+{
+	ignoreDeclarations: [
+		{ font: '0/0 serif' }
+	]
+}
+```
+
 ### `requireSize`
 
 Type: `boolean`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-font-pack",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PostCSS plugin to simplify font declarations by validating only configured font packs are used and adding fallbacks.",
   "main": "dist/plugin.js",
   "types": "dist/plugin.d.ts",

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -116,6 +116,21 @@ test('throws if fallbacks are provided', macro,
 	}
 );
 
+test('ignores a font declaration', macro,
+	'body{font:0/0 serif}',
+	'body{font:0/0 serif}',
+	{
+		ignoreDeclarations: [
+			{ font: '0/0 serif' }
+		],
+		packs: {
+			roboto: {
+				family: ['Roboto', 'Arial', 'sans-serif']
+			}
+		}
+	}
+);
+
 test('resolves a font-family declaration', macro,
 	'body{font-family:roboto}',
 	'body{font-family:Roboto, Arial, sans-serif}',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -25,6 +25,11 @@ const PostCssFontPack = postcss.plugin<PostCssFontPack.Options>('postcss-font-pa
 
 		const lookup = buildLookupTable(packs);
 		const zonesToIgnore = findZonesToIgnore(root);
+		const ignores = options.ignoreDeclarations;
+
+		function isIgnored(decl: postcss.Declaration) {
+			return _.some(options.ignoreDeclarations, { [decl.prop]: decl.value });
+		}
 
 		function isWithinIgnoreRange(decl: postcss.Declaration) {
 			if (
@@ -68,7 +73,7 @@ const PostCssFontPack = postcss.plugin<PostCssFontPack.Options>('postcss-font-pa
 
 			function resolveDeclaration(decl: postcss.Declaration) {
 
-				if (isWithinIgnoreRange(decl)) {
+				if (isIgnored(decl) || isWithinIgnoreRange(decl)) {
 					return;
 				}
 
@@ -206,6 +211,10 @@ namespace PostCssFontPack {
 	 * Plugin options.
 	 */
 	export interface Options {
+		/**
+		 * Declarations to ignore, like CSS hacks (e.g., [{font: '0/0 serif'}]).
+		 */
+		ignoreDeclarations?: { [prop: string]: string; };
 		/**
 		 * When true, an error will be thrown if you have a rule with one or more
 		 * font declarations, but without a font size.


### PR DESCRIPTION
## Options

### `ignoreDeclarations`

Type: `{ [prop: string]: string; }`
Required: `false`
Default: `undefined`

A collection of declarations that you would like to ignore. These could be CSS hacks or something else that you really don't want throwing validation errors. Example below:

```js
{
	ignoreDeclarations: [
		{ font: '0/0 serif' }
	]
}
```
